### PR TITLE
Feedback from reviewers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 /.idea
+*.iml
+.project
+.classpath

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Checkout the `com.climate.squeedo.sqs` namespace for extra goodies like connecti
 
 ## Acknowledgments
 
-Shoutouts to [Jeff Melching](https://github.com/jmelching), Tim Chagnon, and Robert Grailer for being major contributors to this project. 
+Shoutouts to [Jeff Melching](https://github.com/jmelching), Tim Chagnon, and [Robert Grailer](https://github.com/RobertGrailer) for being major contributors to this project. 
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
   :profiles {:dev {:dependencies
                    [[lein-marginalia "0.7.1"]
                     [http-kit "2.1.16"]
-                    [com.climate/claypoole "0.3.1"]]}}
+                    [com.climate/claypoole "0.4.0"]]}}
   :plugins [[lein-marginalia "0.7.1"]]
 
   :test-selectors {:default #(not-any? % #{:integration :benchmark :manual})

--- a/src/com/climate/squeedo/sqs_consumer.clj
+++ b/src/com/climate/squeedo/sqs_consumer.clj
@@ -36,6 +36,9 @@
     [message-channel buf]))
 
 (defn- create-workers
+  "Create workers to actually run the compute function. Workers are expected to be CPU bound
+   or handle all IO in an asynchronous manner.  In the future we may add an option to run computes
+   in a thread/pool that isn't part of the core.async's threadpool."
   [connection worker-size max-concurrent-work message-channel compute]
   (let [done-channel (chan worker-size)
         ; the work-token-channel ensures we only have a fixed numbers of messages processed at one time
@@ -84,15 +87,16 @@
     compute - a compute function that takes two args: a 'message' containing the body of the sqs
               message and a channel on which to ack/nack when done.
     opts -
-           :message-channel-size : the number of messages to prefetch from sqs; default 20 * num-listeners
-           :num-workers : the number of workers processing messages concurrently
-           :num-listeners : the number of listeners polling from sqs. default is (num-workers / 10)
-                            since each listener dequeues up to 10 messages at a time
-           :dequeue-limit : the number of messages to dequeue at a time; default 10
-           :max-concurrent-work : the maximum number of total messages processed.  This is mainly for
-                            asynch workflows; default num-workers
-           :dl-queue-name : the dead letter queue to which messages that are failed the maximum number of
-                            times will go (will be created if necessary). Defaults to (str queue-name \"-failed\")
+       :message-channel-size : the number of messages to prefetch from sqs; default 20 * num-listeners
+       :num-workers : the number of workers processing messages concurrently
+       :num-listeners : the number of listeners polling from sqs. default is (num-workers / 10)
+                        since each listener dequeues up to 10 messages at a time
+       :dequeue-limit : the number of messages to dequeue at a time; default 10
+       :max-concurrent-work : the maximum number of total messages processed.  This is mainly for
+                        asynch workflows; default num-workers
+       :dl-queue-name : the dead letter queue to which messages that are failed the maximum number of
+                        times will go (will be created if necessary).
+                        Defaults to (str queue-name \"-failed\")
    outputs:
     a map with keys, :done-channel - the channel to send messages to be acked
                      :message-channel - unused by the client.

--- a/test/com/climate/squeedo/sqs_test.clj
+++ b/test/com/climate/squeedo/sqs_test.clj
@@ -10,39 +10,14 @@
 ;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 ;; or implied.  See the License for the specific language governing permissions
 ;; and limitations under the License.
-(ns com.climate.squeedo.test.sqs
+(ns com.climate.squeedo.sqs-test
   (:require
-    [cemerick.bandalore :as bandalore]
     [clojure.test :refer :all]
     [clojure.tools.logging :as log]
     [com.climate.squeedo.sqs :as sqs]
+    [com.climate.squeedo.test-utils :refer [with-temporary-queue]]
     [clojure.tools.reader.edn :as edn]
     [cheshire.core :as json]))
-
-(defmacro with-temporary-queue
-  [[queue-name & [dead-letter-queue-name]] & body]
-  (let [dead-letter-queue-name (or dead-letter-queue-name
-                                   (gensym "dead-letter-queue-name"))]
-    `(let [r# (rand-int Integer/MAX_VALUE)
-           ~queue-name (format "test_squeedo_%s" r#)
-           ~dead-letter-queue-name (format "test_squeedo_dead-letter_%s" r#)]
-       (log/infof "Using testing queue %s" ~queue-name)
-       (when ~dead-letter-queue-name
-         (log/infof "Using testing dead-letter queue %s" ~dead-letter-queue-name))
-       (try
-         ~@body
-         (finally
-           ;; Definitely clean up after ourselves!
-           (let [client# (bandalore/create-client)
-                 queue-url# (bandalore/create-queue client# ~queue-name)]
-             (bandalore/delete-queue client# queue-url#)
-             (log/infof "Deleted testing queue %s" ~queue-name)
-             (when ~dead-letter-queue-name
-               (let [dlq-url# (bandalore/create-queue client#
-                                                      ~dead-letter-queue-name)]
-                 (bandalore/delete-queue client# dlq-url#))
-               (log/infof "Deleted testing dead letter queue %s"
-                          ~dead-letter-queue-name))))))))
 
 (deftest valid-queue-name
   (testing "Queue name validity with special characters"
@@ -56,7 +31,6 @@
   (testing "Empty queue name"
     (is (thrown? IllegalArgumentException
           (sqs/validate-queue-name! "")))))
-
 
 (defn dequeue-1
   "Convenience function for some of these tests"

--- a/test/com/climate/squeedo/test_utils.clj
+++ b/test/com/climate/squeedo/test_utils.clj
@@ -1,0 +1,28 @@
+(ns com.climate.squeedo.test-utils
+  (:require [clojure.tools.logging :as log]
+            [cemerick.bandalore :as bandalore]))
+
+(defmacro with-temporary-queue
+  [[queue-name & [dead-letter-queue-name]] & body]
+  (let [dead-letter-queue-name (or dead-letter-queue-name
+                                   (gensym "dead-letter-queue-name"))]
+    `(let [r# (rand-int Integer/MAX_VALUE)
+           ~queue-name (format "test_squeedo_%s" r#)
+           ~dead-letter-queue-name (format "test_squeedo_dead-letter_%s" r#)]
+       (log/infof "Using testing queue %s" ~queue-name)
+       (when ~dead-letter-queue-name
+         (log/infof "Using testing dead-letter queue %s" ~dead-letter-queue-name))
+       (try
+         ~@body
+         (finally
+           ;; Definitely clean up after ourselves!
+           (let [client# (bandalore/create-client)
+                 queue-url# (bandalore/create-queue client# ~queue-name)]
+             (bandalore/delete-queue client# queue-url#)
+             (log/infof "Deleted testing queue %s" ~queue-name)
+             (when ~dead-letter-queue-name
+               (let [dlq-url# (bandalore/create-queue client#
+                                                      ~dead-letter-queue-name)]
+                 (bandalore/delete-queue client# dlq-url#))
+               (log/infof "Deleted testing dead letter queue %s"
+                          ~dead-letter-queue-name))))))))


### PR DESCRIPTION
- renamed namespaces to exclude test
- Use Claypoole 0.4.0 as your dev dependency
- clean up a few long lines
- pull out with-temporary-queue into helper namespace
- add docstring to create-queue-listener
