### PR TITLE
Remove bandalore src dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## x.x.x
+## 0.3.0-SNAPSHOT (unreleased)
 
-* remove bandalore dependecy
-* fix #30
-* fix #34
+* **BREAKING**
+  * queue attributes are only set when `com.climate.squeedo.sqs/mk-connection` creates a new sqs queue
+    * if an existing queue is found, queue attributes are not applied (this includes dead-letter/redrive configuration)
+    * squeedo will emit a `WARN` log when this occurs
+    * allows reading from queues that already exist for consumers without create permissions (#34)
+    * new api function, `com.climate.squeedo.sqs/set-queue-attributes`, which allows ad-hoc calls to set attributes
+    for those who need it
+  * support binary message attributes (#30)
+  * remove bandalore as a source dependency
 
 ## 0.2.1 (June 26, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## x.x.x
+
+* remove bandalore dependecy
+* fix #30
+* fix #34
+
 ## 0.2.1 (June 26, 2017)
 
 * consumer middleware for deserialization and exception logging

--- a/README.md
+++ b/README.md
@@ -7,26 +7,26 @@ in its raw format, so it's up to the caller to determine the proper reader for t
 
 ## Latest version
 
-[![Clojars Project](http://clojars.org/com.climate/squeedo/latest-version.svg )](http://clojars.org/com.climate/squeedo )
+[![Clojars Project](http://clojars.org/com.climate/squeedo/latest-version.svg)](http://clojars.org/com.climate/squeedo)
 [![Dependencies Status](http://jarkeeper.com/TheClimateCorporation/squeedo/status.svg)](http://jarkeeper.com/TheClimateCorporation/squeedo)
 
 ## Inspiration
 
 Squeedo's inspiration came from our continual need to quickly process lots of messages from SQS. We found that the
 code to support these processes was quite similar in that it often involved a lot of plumbing of listening to SQS,
-pulling messages,  processing them with some kind of threadpool and then acking them back.  The goal was to make this
+pulling messages, processing them with some kind of threadpool and then acking them back. The goal was to make this
 easier by somehow simply passing a compute function that would handle all of the plumbing and allow us to focus on
 the compute logic of what to do with the message.
 
 After several iterations of basing this plumbing code on threadpools, we quickly found that we couldn't get the kind of
-throughput we wanted simply by tuning only the number of threads.  We needed something more dynamic, that would adapt
+throughput we wanted simply by tuning only the number of threads. We needed something more dynamic, that would adapt
 better to the number of cores it ran on and would squeeze every last bit of CPU from our EC2 instances. After reading
 this blog post http://martintrojer.github.io/clojure/2013/07/07/coreasync-and-blocking-io we were inspired to use
 core.async and Squeedo was born.
 
 ## Why use Squeedo?
 
-Where Squeedo shines is in its ability to push CPU utilization to the max without managing a threadpool.  It is
+Where Squeedo shines is in its ability to push CPU utilization to the max without managing a threadpool. It is
 especially good when combined with an non-blocking I/O web client library like http-kit as mentioned in the blog above.
 
 ## Simple quick start
@@ -50,7 +50,7 @@ In its simplest form, Squeedo is composed of only 2 parts, a compute function an
 (stop-consumer consumer)
 ```
 
-The compute function must post to the done-channel even for exceptions.  This will ack/nack each message.  Squeedo
+The compute function must post to the done-channel even for exceptions. This will ack/nack each message. Squeedo
 listens to the done-channel to know when work is complete so it can pass your compute function another message to
 process.
 
@@ -143,18 +143,19 @@ your workflow beyond what the very reasonable defaults do out of the box.
 * **:num-listeners** - the number of listeners polling from SQS. default is (num-workers /dequeue-limit) since each listener dequeues up to dequeue-limit messages at a time. If you have a really fast process, you can actually starve the compute function of messages and thus need more listeners pulling from SQS.
 * **:dequeue-limit** - the number of messages to dequeue at a time; default 10
 * **:max-concurrent-work** - the maximum number of total messages processed concurrently. This is mainly for async workflows where you can have work started and are waiting for parked IO threads to complete; default num-workers. This allows you to always keep the CPU's busy by having data returned by IO ready to be processed. Its really a memory game at this point -- how much data you can buffer that's ready to be processed by your asynchronous http clients.
-* **:dl-queue-name** - the dead letter SQS queue to which repeatedly failed messages will go.  A message that fails to process the maximum number of SQS receives is sent to the dead letter queue. (see SQS Redrive Policy)  The queue will be created if necessary.  Defaults to (str QUEUE-NAME \”-failed\”) where QUEUE-NAME is the name of the queue passed into the start-consumer function.
+* **:dl-queue-name** - the dead letter SQS queue to which repeatedly failed messages will go. A message that fails to process the maximum number of SQS receives is sent to the dead letter queue. (see SQS Redrive Policy) The queue will be created if necessary. Defaults to (str QUEUE-NAME \”-failed\”) where QUEUE-NAME is the name of the queue passed into the start-consumer function.
 * **:client** - the SQS client used to start the consumer. By default an SQS client is created internally using instance credentials, but a client can be passed in to be used. This allows you to use a client you may have already created with some specific properties (e.g. manually overridden AWS credentials).
 
 ## Additional goodies
 
 Checkout the `com.climate.squeedo.sqs` namespace for extra goodies like connecting to queues, enqueuing and dequeing
-messages, and acking and nacking.  Mostly addons to https://github.com/cemerick/bandalore
+messages, and acking and nacking.
 
 ## Acknowledgments
 
-Shoutouts to [Jeff Melching](https://github.com/jmelching), [Tim Chagnon](https://github.com/tchagnon), and
+* Shoutouts to [Jeff Melching](https://github.com/jmelching), [Tim Chagnon](https://github.com/tchagnon), and
 [Robert Grailer](https://github.com/RobertGrailer) for being major contributors to this project.
+* Bandalore, which Squeedo originally leveraged as its internal SQS client (https://github.com/cemerick/bandalore).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ in its raw format, so it's up to the caller to determine the proper reader for t
 [![Clojars Project](http://clojars.org/com.climate/squeedo/latest-version.svg)](http://clojars.org/com.climate/squeedo)
 [![Dependencies Status](http://jarkeeper.com/TheClimateCorporation/squeedo/status.svg)](http://jarkeeper.com/TheClimateCorporation/squeedo)
 
+See [CHANGELOG](https://github.com/TheClimateCorporation/squeedo/blob/master/CHANGELOG.md) for release notes.
+
 ## Inspiration
 
 Squeedo's inspiration came from our continual need to quickly process lots of messages from SQS. We found that the
@@ -148,7 +150,7 @@ your workflow beyond what the very reasonable defaults do out of the box.
 
 ## Additional goodies
 
-Checkout the `com.climate.squeedo.sqs` namespace for extra goodies like connecting to queues, enqueuing and dequeing
+Checkout the `com.climate.squeedo.sqs` namespace for extra goodies like connecting to queues, enqueuing and dequeuing
 messages, and acking and nacking.
 
 ## Acknowledgments

--- a/project.clj
+++ b/project.clj
@@ -21,13 +21,13 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/core.async "0.3.442"]
                  [cheshire "5.7.0"]
-                 [com.cemerick/bandalore "0.0.6"
-                  :exclusions [com.amazonaws/aws-java-sdk]]
                  [com.amazonaws/aws-java-sdk-sqs "1.11.98"]]
 
-  :profiles {:dev {:dependencies
-                   [[http-kit "2.2.0"]
-                    [com.climate/claypoole "1.1.4"]]}}
+  :profiles {:dev {:global-vars {*warn-on-reflection* true}
+                   :dependencies [[http-kit "2.2.0"]
+                                  [com.cemerick/bandalore "0.0.6"
+                                   :exclusions [com.amazonaws/aws-java-sdk]]
+                                  [com.climate/claypoole "1.1.4"]]}}
 
   :plugins [[lein-ancient "0.5.5"]]
 

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
 ;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 ;; or implied.  See the License for the specific language governing permissions
 ;; and limitations under the License.
-(defproject com.climate/squeedo "0.2.2-SNAPSHOT"
+(defproject com.climate/squeedo "0.3.0-SNAPSHOT"
   :description "Squeedo: The sexiest message consumer ever (™)"
   :url "http://github.com/TheClimateCorporation/squeedo/"
   :min-lein-version "2.0.0"

--- a/src/com/climate/squeedo/sqs.clj
+++ b/src/com/climate/squeedo/sqs.clj
@@ -84,11 +84,9 @@
                        "VisibilityTimeout"             auto-retry-seconds}
         ; Tip: don't try sending attrs as create-queue's 'options' param: they aren't the same
         queue-url (try
-                    (.getQueueUrl
-                      (.getQueueUrl client queue-name))
+                    (.getQueueUrl (.getQueueUrl client queue-name))
                     (catch QueueDoesNotExistException _
-                      (.getQueueUrl
-                        (.createQueue client queue-name))))
+                      (.getQueueUrl (.createQueue client queue-name))))
         attributes (->> (merge default-attrs
                                queue-attrs
                                (when dead-letter-url

--- a/src/com/climate/squeedo/sqs.clj
+++ b/src/com/climate/squeedo/sqs.clj
@@ -86,19 +86,21 @@
 
   Optionally takes a dead letter queue URL (Amazon Resource Name),
   a queue that already exists, that gets associated with the returned queue."
-  [^AmazonSQSClient client ^String queue-url queue-attrs dead-letter-url]
-  (let [default-attrs {"DelaySeconds"                  0       ; delay after enqueue
-                       "MessageRetentionPeriod"        1209600 ; max, 14 days
-                       "ReceiveMessageWaitTimeSeconds" poll-timeout-seconds
-                       "VisibilityTimeout"             auto-retry-seconds}
-        redrive-attrs (when dead-letter-url
-                        (redrive-policy client dead-letter-url))]
-    (->> (merge default-attrs
-                queue-attrs
-                redrive-attrs)
-         (map (fn [[k v]] [(str k) (str v)]))
-         (into {})
-         (.setQueueAttributes client queue-url))))
+  ([client queue-url queue-attrs]
+   (set-attributes client queue-url queue-attrs nil))
+  ([^AmazonSQSClient client ^String queue-url queue-attrs dead-letter-url]
+   (let [default-attrs {"DelaySeconds"                  0       ; delay after enqueue
+                        "MessageRetentionPeriod"        1209600 ; max, 14 days
+                        "ReceiveMessageWaitTimeSeconds" poll-timeout-seconds
+                        "VisibilityTimeout"             auto-retry-seconds}
+         redrive-attrs (when dead-letter-url
+                         (redrive-policy client dead-letter-url))]
+     (->> (merge default-attrs
+                 queue-attrs
+                 redrive-attrs)
+          (map (fn [[k v]] [(str k) (str v)]))
+          (into {})
+          (.setQueueAttributes client queue-url)))))
 
 (defn- get-or-create-queue
   "Get or create an SQS queue with the given name and specified queue attributes.

--- a/src/com/climate/squeedo/sqs.clj
+++ b/src/com/climate/squeedo/sqs.clj
@@ -62,9 +62,9 @@
 (defn- redrive-policy
   "Encode the RedrivePolicy for a dead letter queue.
   http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html"
-  [^AmazonSQSClient client ^String dead-letter-queue-url]
+  [^AmazonSQSClient client ^String dead-letter-url]
   (let [queue-arn (-> client
-                      (.getQueueAttributes dead-letter-queue-url ["QueueArn"])
+                      (.getQueueAttributes dead-letter-url ["QueueArn"])
                       (.getAttributes)
                       (get "QueueArn"))]
     {"RedrivePolicy"
@@ -73,30 +73,46 @@
                             "deadLetterTargetArn" queue-arn})}))
 
 (defn- get-queue
-  "Retrieve the queue URL (Amazon Resource Name) from SQS.
+  "Retrieve the queue URL (Amazon Resource Name) from SQS."
+  [^AmazonSQSClient client ^String queue-name]
+  (try
+    (.getQueueUrl (.getQueueUrl client queue-name))
+    (catch QueueDoesNotExistException _
+      (log/debugf "SQS queue %s does not exist" queue-name)
+      nil)))
+
+(defn- set-attributes
+  "Set queue attributes for the speecified queue URL.
 
   Optionally takes a dead letter queue URL (Amazon Resource Name),
   a queue that already exists, that gets associated with the returned queue."
-  ([client queue-name queue-attrs]
-   (get-queue client queue-name queue-attrs nil))
-  ([^AmazonSQSClient client ^String queue-name queue-attrs dead-letter-url]
-   (let [default-attrs {"DelaySeconds"                  0       ; delay after enqueue
-                        "MessageRetentionPeriod"        1209600 ; max, 14 days
-                        "ReceiveMessageWaitTimeSeconds" poll-timeout-seconds
-                        "VisibilityTimeout"             auto-retry-seconds}
-         queue-url (try
-                     (.getQueueUrl (.getQueueUrl client queue-name))
-                     (catch QueueDoesNotExistException _
-                       (.getQueueUrl (.createQueue client queue-name))))
-         redrive-attrs (when dead-letter-url
-                         (redrive-policy client dead-letter-url))]
-     (->> (merge default-attrs
-                 queue-attrs
-                 redrive-attrs)
-          (map (fn [[k v]] [(str k) (str v)]))
-          (into {})
-          (.setQueueAttributes client queue-url))
-     queue-url)))
+  [^AmazonSQSClient client ^String queue-url queue-attrs dead-letter-url]
+  (let [default-attrs {"DelaySeconds"                  0       ; delay after enqueue
+                       "MessageRetentionPeriod"        1209600 ; max, 14 days
+                       "ReceiveMessageWaitTimeSeconds" poll-timeout-seconds
+                       "VisibilityTimeout"             auto-retry-seconds}
+        redrive-attrs (when dead-letter-url
+                        (redrive-policy client dead-letter-url))]
+    (->> (merge default-attrs
+                queue-attrs
+                redrive-attrs)
+         (map (fn [[k v]] [(str k) (str v)]))
+         (into {})
+         (.setQueueAttributes client queue-url))))
+
+(defn- get-or-create-queue
+  "Get or create an SQS queue with the given name and specified queue attributes.
+
+  Optionally takes a dead letter queue URL (Amazon Resource Name),
+  a queue that already exists, that gets associated with the returned queue."
+  [^AmazonSQSClient client ^String queue-name queue-attrs dead-letter-url]
+  (if-let [queue-url (get-queue client queue-name)]
+    (do (log/warnf "Found existing queue %s, queue attributes and redrive policy will not be modified." queue-name)
+        queue-url)
+    (let [queue-url (.getQueueUrl (.createQueue client queue-name))]
+      (log/debugf "Created SQS queue %s" queue-name)
+      (set-attributes client queue-url queue-attrs dead-letter-url)
+      queue-url)))
 
 (defn mk-connection
   "Create an SQS connection to a queue identified by string queue-name. This
@@ -108,29 +124,47 @@
 
   Also, it optionally takes attribute maps for the main queue and the dead letter
   queue. These must be maps from string to string, with keys matching standard
-  SQS attribute names."
+  SQS attribute names.
+
+  Note: if the queue already exists, the queue attributes and redrive policy
+  will not be modified. Use `set-queue-attributes` to set attributes on an
+  existing queue."
   [queue-name & {:keys [dead-letter
                         client
                         queue-attributes
                         dead-letter-queue-attributes]}]
   (validate-queue-name! queue-name)
-  (when dead-letter
-    (validate-queue-name! dead-letter))
   (let [client (or client (AmazonSQSClientBuilder/defaultClient))
         dead-letter-connection (when dead-letter
                                  (mk-connection dead-letter
                                                 :client client
                                                 :queue-attributes dead-letter-queue-attributes))
-        queue-url (if dead-letter
-                    (get-queue client queue-name queue-attributes (:queue-url dead-letter-connection))
-                    (get-queue client queue-name queue-attributes))]
+        queue-url (get-or-create-queue
+                    client queue-name queue-attributes (:queue-url dead-letter-connection))]
     (log/infof "Using SQS queue %s at %s" queue-name queue-url)
     (merge
-     {:client     client
-      :queue-name queue-name
-      :queue-url  queue-url}
-     (when dead-letter
-       {:dead-letter (dissoc dead-letter-connection :client)}))))
+      {:client     client
+       :queue-name queue-name
+       :queue-url  queue-url}
+      (when dead-letter
+        {:dead-letter (dissoc dead-letter-connection :client)}))))
+
+(defn set-queue-attributes
+  "Update queue attributes of an existing queue & dead letter queue.
+  The attribute maps must be from string to string, with keys matching standard
+  SQS attribute names.
+
+  Input:
+    queue-connection - A connection to a queue made with mk-connection
+
+    Optional arguments:
+    :queue-attributes - attribute map for the main queue
+    :dead-letter-queue-attributes - attribute map for the dead letter queue"
+  [{:keys [client queue-url dead-letter]} & {:keys [queue-attributes
+                                                    dead-letter-queue-attributes]}]
+  (when (and dead-letter dead-letter-queue-attributes)
+    (set-attributes client (:queue-url dead-letter) dead-letter-queue-attributes))
+  (set-attributes client queue-url queue-attributes (:queue-url dead-letter)))
 
 (defn- build-msg-attributes
   "A helper function to turn a Clojure keyword map into a Map<String,MessageAttributeValue>"
@@ -157,12 +191,12 @@
   "Enqueues a message to a queue.
 
   Input:
-  queue-connection - A connection to a queue made with mk-connection
-  message - The message to be placed on the queue
+    queue-connection - A connection to a queue made with mk-connection
+    message - The message to be placed on the queue
 
-  Optional arguments:
-  :message-attributes - A map of SQS Attributes to apply to this message.
-  :serialization-fn - A function that serializes the message you want to enqueue to a string
+    Optional arguments:
+    :message-attributes - A map of SQS Attributes to apply to this message.
+    :serialization-fn - A function that serializes the message you want to enqueue to a string
     By default, pr-str will be used"
   [queue-connection message & opts]
   (let [{:keys [client queue-name queue-url]} queue-connection
@@ -195,32 +229,34 @@
 
 (defn- receive
   "Receives one or more messages from the queue specified by the given URL.
-   Optionally accepts keyword arguments:
+  Input:
+    client - AmazonSQSClient
+    queue-url - url to the SQS resource
 
-   :limit - between 1 (default) and 10, the maximum number of messages to receive
-   :visibility - seconds the received messages should not be delivered to other
-             receivers; defaults to the queue's visibility attribute
-   :attributes - a collection of string names of :attributes to include in
-             received messages; e.g. #{\"All\"} will include all attributes,
-             #{\"SentTimestamp\"} will include only the SentTimestamp attribute, etc.
-             Defaults to the empty set (i.e. no attributes will be included in
-             received messages).
-             See the SQS documentation for all support message attributes.
-   :wait-time-seconds - enables long poll support. time is in seconds, bewteen
-             0 (default - no long polling) and 20.
-             Allows Amazon SQS service to wait until a message is available
-             in the queue before sending a response.
-             See the SQS documentation at (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html)
+    Optional keyword arguments:
+    :limit - between 1 (default) and 10, the maximum number of messages to receive
+    :visibility - seconds the received messages should not be delivered to other
+              receivers; defaults to the queue's visibility attribute
+    :attributes - a collection of string names of :attributes to include in
+              received messages; e.g. #{\"All\"} will include all attributes,
+              #{\"SentTimestamp\"} will include only the SentTimestamp attribute, etc.
+              Defaults to the empty set (i.e. no attributes will be included in
+              received messages).
+              See the SQS documentation for all support message attributes.
+    :wait-time-seconds - enables long poll support. time is in seconds, bewteen
+              0 (default - no long polling) and 20.
+              Allows Amazon SQS service to wait until a message is available
+              in the queue before sending a response.
+              See the SQS documentation at (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html)
 
-   Returns a seq of maps with these slots:
-
-   :attributes - message attributes
-   :body - the string body of the message
-   :body-md5 - the MD5 checksum of :body
-   :id - the message's ID
-   :receipt-handle - the ID used to delete the message from the queue after
-             it has been fully processed.
-   :source-queue - the URL of the queue from which the message was received"
+  Returns a seq of maps with these slots:
+    :attributes - message attributes
+    :body - the string body of the message
+    :body-md5 - the MD5 checksum of :body
+    :id - the message's ID
+    :receipt-handle - the ID used to delete the message from the queue after
+              it has been fully processed.
+    :source-queue - the URL of the queue from which the message was received"
   [^AmazonSQSClient client queue-url & {:keys [limit
                                                visibility
                                                wait-time-seconds

--- a/src/com/climate/squeedo/sqs_consumer.clj
+++ b/src/com/climate/squeedo/sqs_consumer.clj
@@ -12,24 +12,23 @@
 ;; and limitations under the License.
 (ns com.climate.squeedo.sqs-consumer
   "Functions for using Amazon Simple Queueing Service to request and perform
- computation."
+  computation."
   (:require
     [clojure.core.async :refer [close! go-loop go >! <! chan buffer onto-chan]]
     [clojure.core.async.impl.protocols :refer [closed?]]
-    [com.climate.squeedo.sqs :as gsqs]))
+    [com.climate.squeedo.sqs :as sqs]))
 
 (defn- create-queue-listener
-  " kick off a listener in the background that eagerly grabs messages as quickly
-    as possible and fetches them into a buffered channel.  This will park the thread
-    if the message channel is full. (ie. don't prefetch too many messages as there is a memory
-    impact, and they have to get processed before timing out.)
-  "
+  "Kick off a listener in the background that eagerly grabs messages as quickly
+  as possible and fetches them into a buffered channel.  This will park the thread
+  if the message channel is full. (ie. don't prefetch too many messages as there is a memory
+  impact, and they have to get processed before timing out.)"
   [connection num-listeners buffer-size dequeue-limit]
   (let [buf (buffer buffer-size)
         message-channel (chan buf)]
     (dotimes [_ num-listeners]
       (go (while
-            (let [messages (gsqs/dequeue connection :limit dequeue-limit)]
+            (let [messages (sqs/dequeue connection :limit dequeue-limit)]
               ; block until all messages are put onto message-channel
               (<! (onto-chan message-channel messages false))
               (not (closed? message-channel))))))
@@ -37,7 +36,7 @@
 
 (defn- create-workers
   "Create workers to run the compute function. Workers are expected to be CPU bound or handle all IO in an asynchronous
-  manner.  In the future we may add an option to run computes in a thread/pool that isn't part of the core.async's
+  manner. In the future we may add an option to run computes in a thread/pool that isn't part of the core.async's
   threadpool."
   [connection worker-size max-concurrent-work message-channel compute]
   (let [done-channel (chan worker-size)
@@ -61,9 +60,9 @@
           ; (n)ack the message asynchronously
           (let [nack (:nack message)]
             (cond
-              (integer? nack) (go (gsqs/nack connection message (:nack message)))
-              nack            (go (gsqs/nack connection message))
-              :else           (go (gsqs/ack connection message))))
+              (integer? nack) (go (sqs/nack connection message (:nack message)))
+              nack            (go (sqs/nack connection message))
+              :else           (go (sqs/ack connection message))))
           (recur))))
     done-channel))
 
@@ -126,7 +125,7 @@
 
    This code is atom free :)
 
-   inputs:
+   Input:
     queue-name - the name of an sqs queue (will be created if necessary)
 
     compute - a compute function that takes two args: a 'message' containing the body of the sqs
@@ -144,16 +143,15 @@
                         Defaults to (str queue-name \"-failed\")
        :client        : the bandalore sqs client to use (if missing, sqs/mk-connection will create
                         the client)
-   outputs:
+   Output:
     a map with keys, :done-channel - the channel to send messages to be acked
-                     :message-channel - unused by the client.
-  "
+                     :message-channel - unused by the client."
   [queue-name compute & opts]
   (let [options (->options-map opts)
         dead-letter-queue-name (get-dead-letter-queue-name queue-name options)
-        connection (gsqs/mk-connection queue-name
-                                       :dead-letter dead-letter-queue-name
-                                       :client      (:client options))
+        connection (sqs/mk-connection queue-name
+                                      :dead-letter dead-letter-queue-name
+                                      :client      (:client options))
         worker-count (get-worker-count options)
         listener-count (get-listener-count worker-count options)
         message-channel-size (get-message-channel-size listener-count options)

--- a/src/com/climate/squeedo/sqs_consumer.clj
+++ b/src/com/climate/squeedo/sqs_consumer.clj
@@ -141,7 +141,7 @@
        :dl-queue-name : the dead letter queue to which messages that are failed the maximum number of
                         times will go (will be created if necessary).
                         Defaults to (str queue-name \"-failed\")
-       :client        : the bandalore sqs client to use (if missing, sqs/mk-connection will create
+       :client        : the sqs client to use (if missing, sqs/mk-connection will create
                         the client)
    Output:
     a map with keys, :done-channel - the channel to send messages to be acked

--- a/test/com/climate/squeedo/sqs_test.clj
+++ b/test/com/climate/squeedo/sqs_test.clj
@@ -50,14 +50,14 @@
         (is (= "1" (get (band/queue-attrs client queue-url) "VisibilityTimeout")))
         (is (= "2" (get (band/queue-attrs client (:queue-url dead-letter)) "VisibilityTimeout")))))
 
-    (testing "pre-existing queue, changing attributes"
+    (testing "pre-existing queue, does not change attributes"
       (let [{:keys [client queue-url dead-letter]}
             (sqs/mk-connection queue
                                :dead-letter dl-queue
                                :queue-attributes {"VisibilityTimeout" "3"}
                                :dead-letter-queue-attributes {"VisibilityTimeout" "4"})]
-        (is (= "3" (get (band/queue-attrs client queue-url) "VisibilityTimeout")))
-        (is (= "4" (get (band/queue-attrs client (:queue-url dead-letter)) "VisibilityTimeout")))))))
+        (is (= "1" (get (band/queue-attrs client queue-url) "VisibilityTimeout")))
+        (is (= "2" (get (band/queue-attrs client (:queue-url dead-letter)) "VisibilityTimeout")))))))
 
 (deftest ^:integration test-multiple-formats
   (with-temporary-queue


### PR DESCRIPTION
Directly use Java SQS API.

- use non-deprecated methods
- more efficient get and set queue attributes
- fix #34 (only create queue when needed)
- fix #30 (support binary message attributes)
- docstring/README polish