### PR TITLE
separate connection and configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## 0.2.2 (November 9, 2017)
 
-* support and validate fifo queue names (thanks @lainiewright!)
+* support and validate FIFO queue names (thanks @lainiewright!)
 * **BREAKING**
   * queue attributes are only set when `com.climate.squeedo.sqs/mk-connection` creates a new sqs queue
     * if an existing queue is found, queue attributes are not applied (this includes dead-letter/redrive configuration)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-SNAPSHOT (unreleased)
+## 1.0.0-beta1 (unreleased)
 
 * support binary message attributes (#30)
 * remove bandalore as a source dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 ## 0.3.0-SNAPSHOT (unreleased)
 
+* support binary message attributes (#30)
+* remove bandalore as a source dependency
 * **BREAKING**
-  * queue attributes are only set when `com.climate.squeedo.sqs/mk-connection` creates a new sqs queue
-    * if an existing queue is found, queue attributes are not applied (this includes dead-letter/redrive configuration)
-    * squeedo will emit a `WARN` log when this occurs
-    * allows reading from queues that already exist for consumers without create permissions (#34)
-    * new api function, `com.climate.squeedo.sqs/set-queue-attributes`, which allows ad-hoc calls to set attributes
-    for those who need it
-  * support binary message attributes (#30)
-  * remove bandalore as a source dependency
+  * queue attributes are only set via `com.climate.squeedo.sqs/configure-queue`
+    * `configure-queue` will create the specified queue (and dead letter queue) if
+      it does not exist.
+    * removed attribute options from `com.climate.squeedo.sqs/mk-connection`.
+      this function now only makes a connection and returns a reusable connection object.
+      a `QueueDoesNotExistException` exception will be thrown if the queue does not exist
+      (use `configure-queue` to create the queue first).
+    * removed dead letter queue option in `com.climate.squeedo.sqs-consumer/start-consumer`.
+      use `com.climate.squeedo.sqs/configure-queue` to set up dead letter queue.
+    * allows reading from queues that already exist for consumers without create
+      permissions (#34).
+    * simplifies creating sqs consumers for _dead letter_ queues (a dead letter queue
+      is not created by default when starting a consumer).
 
 ## 0.2.1 (June 26, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-SNAPSHOT (unreleased)
+## 1.0.0-SNAPSHOT (unreleased)
 
 * support binary message attributes (#30)
 * remove bandalore as a source dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@
 * remove bandalore as a source dependency
 * **BREAKING**
   * queue attributes are only set via `com.climate.squeedo.sqs/configure-queue`
-    * `configure-queue` will create the specified queue (and dead letter queue) if
-      it does not exist.
+    * allows reading from queues that already exist for consumers without create
+      permissions (#34).
+    * `com.climate.squeedo.sqs/configure-queue` will create the specified
+      queue (and dead letter queue) if it does not exist.
     * removed attribute options from `com.climate.squeedo.sqs/mk-connection`.
       this function now only makes a connection and returns a reusable connection object.
       a `QueueDoesNotExistException` exception will be thrown if the queue does not exist
-      (use `configure-queue` to create the queue first).
+      (use `com.climate.squeedo.sqs/configure-queue` to create the queue first).
     * removed dead letter queue option in `com.climate.squeedo.sqs-consumer/start-consumer`.
       use `com.climate.squeedo.sqs/configure-queue` to set up dead letter queue.
-    * allows reading from queues that already exist for consumers without create
-      permissions (#34).
-    * simplifies creating sqs consumers for _dead letter_ queues (a dead letter queue
-      is not created by default when starting a consumer).
+    * removed the default behavior of creating a dead letter queue when starting a
+      consumer.
 
 ## 0.2.1 (June 26, 2017)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ in its raw format, so it's up to the caller to determine the proper reader for t
 [![Clojars Project](http://clojars.org/com.climate/squeedo/latest-version.svg)](http://clojars.org/com.climate/squeedo)
 [![Dependencies Status](http://jarkeeper.com/TheClimateCorporation/squeedo/status.svg)](http://jarkeeper.com/TheClimateCorporation/squeedo)
 
+## Changes
+
+Version `1.0.0` features breaking changes to queue connection and configuration.
 See [CHANGELOG](https://github.com/TheClimateCorporation/squeedo/blob/master/CHANGELOG.md) for release notes.
 
 ## Inspiration

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ soon as possible) or you can give an integer value in seconds.
 
 ;;when done listening
 ;; (stop-consumer consumer)
-
 ```
 
 ## Usage in Jetty based Ring app
@@ -145,13 +144,28 @@ your workflow beyond what the very reasonable defaults do out of the box.
 * **:num-listeners** - the number of listeners polling from SQS. default is (num-workers /dequeue-limit) since each listener dequeues up to dequeue-limit messages at a time. If you have a really fast process, you can actually starve the compute function of messages and thus need more listeners pulling from SQS.
 * **:dequeue-limit** - the number of messages to dequeue at a time; default 10
 * **:max-concurrent-work** - the maximum number of total messages processed concurrently. This is mainly for async workflows where you can have work started and are waiting for parked IO threads to complete; default num-workers. This allows you to always keep the CPU's busy by having data returned by IO ready to be processed. Its really a memory game at this point -- how much data you can buffer that's ready to be processed by your asynchronous http clients.
-* **:dl-queue-name** - the dead letter SQS queue to which repeatedly failed messages will go. A message that fails to process the maximum number of SQS receives is sent to the dead letter queue. (see SQS Redrive Policy) The queue will be created if necessary. Defaults to (str QUEUE-NAME \”-failed\”) where QUEUE-NAME is the name of the queue passed into the start-consumer function.
 * **:client** - the SQS client used to start the consumer. By default an SQS client is created internally using instance credentials, but a client can be passed in to be used. This allows you to use a client you may have already created with some specific properties (e.g. manually overridden AWS credentials).
 
 ## Additional goodies
 
-Checkout the `com.climate.squeedo.sqs` namespace for extra goodies like connecting to queues, enqueuing and dequeuing
-messages, and acking and nacking.
+Checkout the `com.climate.squeedo.sqs` namespace for extra goodies like configuring and connecting to queues,
+enqueuing and dequeuing messages, and acking and nacking.
+
+Example of setting up a queue with custom attributes and a dead letter queue:
+
+```clojure
+(require '[com.climate.squeedo.sqs :as sqs])
+
+(defn initialize-my-queue
+  []
+  (sqs/configure-queue "my-queue"
+                       :queue-attributes {"VisibilityTimeout" "60"}
+                       :dead-letter "my-queue-failed"
+                       :dead-letter-queue-attributes {"VisibilityTimeout" "120"})
+  (sqs/mk-connection "my-queue"))
+
+(def my-queue (initialize-my-queue))
+```
 
 ## Acknowledgments
 

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
 ;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 ;; or implied.  See the License for the specific language governing permissions
 ;; and limitations under the License.
-(defproject com.climate/squeedo "1.0.0-SNAPSHOT"
+(defproject com.climate/squeedo "1.0.0-beta1-SNAPSHOT"
   :description "Squeedo: The sexiest message consumer ever (™)"
   :url "http://github.com/TheClimateCorporation/squeedo/"
   :min-lein-version "2.0.0"

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
 ;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 ;; or implied.  See the License for the specific language governing permissions
 ;; and limitations under the License.
-(defproject com.climate/squeedo "0.3.0-SNAPSHOT"
+(defproject com.climate/squeedo "1.0.0-SNAPSHOT"
   :description "Squeedo: The sexiest message consumer ever (™)"
   :url "http://github.com/TheClimateCorporation/squeedo/"
   :min-lein-version "2.0.0"

--- a/src/com/climate/squeedo/sqs.clj
+++ b/src/com/climate/squeedo/sqs.clj
@@ -105,9 +105,7 @@
       (log/debugf "SQS queue %s does not exist. Creating queue." queue-name)
       (.getQueueUrl (.createQueue client queue-name)))))
 
-(defn- default-client
-  []
-  (AmazonSQSClientBuilder/defaultClient))
+(defn- default-client [] (AmazonSQSClientBuilder/defaultClient))
 
 (defn configure-queue
   "Update an SQS queue with the provided configuration. This should be done
@@ -144,13 +142,22 @@
     (set-attributes client queue-url queue-attributes dead-letter-url)
     queue-url))
 
+(defn- dead-letter-deprecation-warning
+  [options]
+  (when (:dead-letter options)
+    (println
+      (str "WARNING - :dead-letter option for com.climate.squeedo.sqs/mk-connection has"
+           " been removed. Please use com.climate.squeedo.sqs/configure to configure an"
+           " SQS dead letter queue."))))
+
 (defn mk-connection
   "Make an SQS connection to a queue identified by string queue-name. This
   should be done once at startup time.
 
   Will throw QueueDoesNotExistException if the queue does not exist.
   `configure-queue` can be used to create and configure the queue."
-  [^String queue-name & {:keys [client]}]
+  [^String queue-name & {:keys [client] :as options}]
+  (dead-letter-deprecation-warning options)
   (validate-queue-name! queue-name)
   (let [^AmazonSQSClient client (or client (default-client))
         queue-url (.getQueueUrl (.getQueueUrl client queue-name))]

--- a/src/com/climate/squeedo/sqs_consumer.clj
+++ b/src/com/climate/squeedo/sqs_consumer.clj
@@ -105,6 +105,14 @@
   (or (:dequeue-limit options)
       10))
 
+(defn- dead-letter-deprecation-warning
+  [options]
+  (when (:dl-queue-name options)
+    (println
+      (str "WARNING - :dl-queue-name option for com.climate.squeedo.sqs-consumer/start-consumer"
+           " has been removed. Please use com.climate.squeedo.sqs/configure to configure an SQS"
+           " dead letter queue."))))
+
 (defn start-consumer
   "Creates a consumer that reads messages as quickly as possible into a local buffer up
    to the configured buffer size.
@@ -140,6 +148,7 @@
                      :message-channel - unused by the client."
   [queue-name compute & opts]
   (let [options (->options-map opts)
+        _ (dead-letter-deprecation-warning options)
         connection (sqs/mk-connection queue-name :client (:client options))
         worker-count (get-worker-count options)
         listener-count (get-listener-count worker-count options)

--- a/src/com/climate/squeedo/sqs_consumer.clj
+++ b/src/com/climate/squeedo/sqs_consumer.clj
@@ -80,11 +80,6 @@
   []
   (.availableProcessors (Runtime/getRuntime)))
 
-(defn- get-dead-letter-queue-name
-  [queue-name options]
-  (or (:dl-queue-name options)
-      (str queue-name "-failed")))
-
 (defn- get-worker-count
   [options]
   (or (:num-workers options)
@@ -126,32 +121,26 @@
    This code is atom free :)
 
    Input:
-    queue-name - the name of an sqs queue (will be created if necessary)
-
+    queue-name - the name of an sqs queue
     compute - a compute function that takes two args: a 'message' containing the body of the sqs
               message and a channel on which to ack/nack when done.
-    opts -
-       :message-channel-size : the number of messages to prefetch from sqs; default 20 * num-listeners
-       :num-workers : the number of workers processing messages concurrently
-       :num-listeners : the number of listeners polling from sqs. default is (num-workers / 10)
-                        since each listener dequeues up to 10 messages at a time
-       :dequeue-limit : the number of messages to dequeue at a time; default 10
-       :max-concurrent-work : the maximum number of total messages processed.  This is mainly for
-                        asynch workflows; default num-workers
-       :dl-queue-name : the dead letter queue to which messages that are failed the maximum number of
-                        times will go (will be created if necessary).
-                        Defaults to (str queue-name \"-failed\")
-       :client        : the sqs client to use (if missing, sqs/mk-connection will create
-                        the client)
+
+    Optional arguments:
+    :message-channel-size - the number of messages to prefetch from sqs; default 20 * num-listeners
+    :num-workers   - the number of workers processing messages concurrently
+    :num-listeners - the number of listeners polling from sqs. default is (num-workers / 10)
+                     since each listener dequeues up to 10 messages at a time
+    :dequeue-limit - the number of messages to dequeue at a time; default 10
+    :max-concurrent-work - the maximum number of total messages processed.  This is mainly for
+                     asynch workflows; default num-workers
+    :client        - the sqs client to use (if missing, sqs/mk-connection will create
+                     the client)
    Output:
     a map with keys, :done-channel - the channel to send messages to be acked
                      :message-channel - unused by the client."
   [queue-name compute & opts]
   (let [options (->options-map opts)
-        dead-letter-queue-name (get-dead-letter-queue-name queue-name options)
-        connection (sqs/mk-connection queue-name
-                                      :dead-letter dead-letter-queue-name
-                                      :client      (:client options))
+        connection (sqs/mk-connection queue-name :client (:client options))
         worker-count (get-worker-count options)
         listener-count (get-listener-count worker-count options)
         message-channel-size (get-message-channel-size listener-count options)


### PR DESCRIPTION
remove configuration code from `mk-connection`. rename `set-queue-attributes` with more general `configure-queue`, which will create the queue + dead letter queue in addition to setting queue attributes.