### PR TITLE
Validation allows FIFO queue names

### DIFF
--- a/src/com/climate/squeedo/sqs.clj
+++ b/src/com/climate/squeedo/sqs.clj
@@ -41,13 +41,14 @@
 
 (def ^:const invalid-queue-message
   (str "Queue names can only include alphanumeric characters "
-       "hyphens, or underscores. Queue name should be less than "
+       "hyphens, or underscores. A FIFO queue must have the"
+       ".fifo suffix. Queue name should be less than "
        "80 characters."))
 
 (defn valid-queue-name?
   "Returns true if an SQS queue name is valid, false otherwise"
   [queue-name]
-  (and (re-matches #"[A-Za-z0-9_-]+(\Q.fifo\E)?" queue-name)
+  (and (re-matches #"[A-Za-z0-9_-]+(\.fifo)?" queue-name)
        (< (count queue-name) 80)))
 
 (defn validate-queue-name!

--- a/src/com/climate/squeedo/sqs.clj
+++ b/src/com/climate/squeedo/sqs.clj
@@ -42,14 +42,14 @@
 (def ^:const invalid-queue-message
   (str "Queue names can only include alphanumeric characters "
        "hyphens, or underscores. A FIFO queue must have the"
-       ".fifo suffix. Queue name should be less than "
+       ".fifo suffix. Queue name should be no more than "
        "80 characters."))
 
 (defn valid-queue-name?
   "Returns true if an SQS queue name is valid, false otherwise"
   [queue-name]
   (and (re-matches #"[A-Za-z0-9_-]+(\.fifo)?" queue-name)
-       (< (count queue-name) 80)))
+       (<= (count queue-name) 80)))
 
 (defn validate-queue-name!
   "Validates input for SQS queue names.

--- a/src/com/climate/squeedo/sqs.clj
+++ b/src/com/climate/squeedo/sqs.clj
@@ -47,9 +47,8 @@
 (defn valid-queue-name?
   "Returns true if an SQS queue name is valid, false otherwise"
   [queue-name]
-  (not (or (empty? queue-name)
-           (re-find #"[^A-Za-z0-9_-]" queue-name)
-           (>= (count queue-name) 80))))
+  (and (re-matches #"[A-Za-z0-9_-]+(\Q.fifo\E)?" queue-name)
+       (< (count queue-name) 80)))
 
 (defn validate-queue-name!
   "Validates input for SQS queue names.

--- a/test/com/climate/squeedo/sqs_test.clj
+++ b/test/com/climate/squeedo/sqs_test.clj
@@ -29,9 +29,11 @@
     (is (thrown? IllegalArgumentException
           (sqs/validate-queue-name!
             "areally-really-really-really-really-really-really-really-looooooooooooooooonnnnnnggg-queue-name")))
-    (is (nil? (sqs/validate-queue-name! 
-                (str "0123456789" "0123456789" "0123456789" "0123456789"
-                     "0123456789" "0123456789" "0123456789" "0123456789")))))
+    (let [eighty-char-str (->> (repeat "L")
+                               (take 80)
+                               (reduce str))]
+          (is (nil? (sqs/validate-queue-name!
+                      eighty-char-str)))))
   (testing "Empty queue name"
     (is (thrown? IllegalArgumentException
           (sqs/validate-queue-name! ""))))

--- a/test/com/climate/squeedo/sqs_test.clj
+++ b/test/com/climate/squeedo/sqs_test.clj
@@ -28,7 +28,10 @@
   (testing "Queue name length check"
     (is (thrown? IllegalArgumentException
           (sqs/validate-queue-name!
-            "areally-really-really-really-really-really-really-really-looooooooooooooooonnnnnnggg-queue-name"))))
+            "areally-really-really-really-really-really-really-really-looooooooooooooooonnnnnnggg-queue-name")))
+    (is (nil? (sqs/validate-queue-name! 
+                (str "0123456789" "0123456789" "0123456789" "0123456789"
+                     "0123456789" "0123456789" "0123456789" "0123456789")))))
   (testing "Empty queue name"
     (is (thrown? IllegalArgumentException
           (sqs/validate-queue-name! ""))))

--- a/test/com/climate/squeedo/sqs_test.clj
+++ b/test/com/climate/squeedo/sqs_test.clj
@@ -31,7 +31,9 @@
             "areally-really-really-really-really-really-really-really-looooooooooooooooonnnnnnggg-queue-name"))))
   (testing "Empty queue name"
     (is (thrown? IllegalArgumentException
-          (sqs/validate-queue-name! "")))))
+          (sqs/validate-queue-name! ""))))
+  (testing "Queue with .fifo suffix"
+    (is (nil? (sqs/validate-queue-name! "hello-world.fifo")))))
 
 (defn dequeue-1
   "Convenience function for some of these tests"


### PR DESCRIPTION
This allows a connection to be made to a FIFO queue (names must have `.fifo` suffix).