### PR TITLE
add listener threads option

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,18 +10,18 @@
 ;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 ;; or implied.  See the License for the specific language governing permissions
 ;; and limitations under the License.
-(defproject com.climate/squeedo "1.0.1-SNAPSHOT"
+(defproject com.climate/squeedo "1.1.0-SNAPSHOT"
   :description "Squeedo: The sexiest message consumer ever (™)"
   :url "http://github.com/TheClimateCorporation/squeedo/"
   :min-lein-version "2.0.0"
   :license {:name "Apache License Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"
             :distribution :repo}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [org.clojure/core.async "0.3.442"]
-                 [cheshire "5.7.0"]
-                 [com.amazonaws/aws-java-sdk-sqs "1.11.98"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/tools.logging "0.4.0"]
+                 [org.clojure/core.async "0.4.474"]
+                 [cheshire "5.8.0"]
+                 [com.amazonaws/aws-java-sdk-sqs "1.11.306"]]
 
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
                    :dependencies [[http-kit "2.2.0"]
@@ -29,12 +29,15 @@
                                    :exclusions [com.amazonaws/aws-java-sdk]]
                                   [com.climate/claypoole "1.1.4"]]}}
 
-  :plugins [[lein-ancient "0.5.5"]]
+  :plugins [[lein-ancient "0.6.15"]]
 
   :deploy-repositories [["releases" :clojars]]
 
-  :test-selectors {:default #(not-any? % #{:integration :benchmark :manual})
+  :test-selectors {:default #(not-any? % #{:integration :benchmark
+                                           :example-cpu :example-listener-threads})
                    :integration :integration
+                   :wip :wip
                    :benchmark :benchmark
-                   :manual :manual
+                   :example-cpu :example-cpu
+                   :example-listener-threads :example-listener-threads
                    :all (fn [_] true)})

--- a/test/com/climate/squeedo/test_utils.clj
+++ b/test/com/climate/squeedo/test_utils.clj
@@ -30,6 +30,8 @@
               (map vector queue-syms)
               (apply concat)
               (vec))
-     ~@body
-     (let [client# (bandalore/create-client)]
-       (dorun (map (partial destroy-queue client#) ~queue-syms)))))
+     (try
+       ~@body
+       (finally
+         (let [client# (bandalore/create-client)]
+           (dorun (map (partial destroy-queue client#) ~queue-syms)))))))


### PR DESCRIPTION
allow users to configure consumer to create listeners on separate threads.

listeners by default are run from go threads. we're using the blocking receive message method in the sqs java client (with a 10 second poll timeout), so wtih a large number of queues, the listeners block other go loops. squeedo will now instead create listeners in `clojure.core.async/thread`s when the `:listener-threads?` option is set to true.

relates to #37