### PR TITLE
Use string as default for unknown data types

### DIFF
--- a/src/com/climate/squeedo/sqs.clj
+++ b/src/com/climate/squeedo/sqs.clj
@@ -235,7 +235,8 @@
                 [(keyword k) (case (.getDataType mav)
                                "String" (.getStringValue mav)
                                "Number" (.getStringValue mav)
-                               "Binary" (.getBinaryValue mav))]))
+                               "Binary" (.getBinaryValue mav)
+                               (.getStringValue mav))]))
          (into {}))))
 
 (defn- message-map


### PR DESCRIPTION
SQS Message attributes allows custom data types which causes squeedo to fail (stacktrace below) because it doesn't have a default clause for unknown data types.

This PR avoid errors from spring producers (check spring-cloud/spring-cloud-aws#221)
```
2019-02-20 22:17:05.387 ERROR async-dispatch-6 my-app - Uncaught Exception
java.lang.IllegalArgumentException: No matching clause: String.Number.java.lang.Long
    at com.climate.squeedo.sqs$clojurify_message_attributes$fn__20619.invoke(sqs.clj:235)
    at clojure.core$map$fn__5587.invoke(core.clj:2745)
    at clojure.lang.LazySeq.sval(LazySeq.java:40)
    at clojure.lang.LazySeq.seq(LazySeq.java:49)
    at clojure.lang.Cons.next(Cons.java:39)
    at clojure.lang.RT.next(RT.java:706)
    at clojure.core$next__5108.invokeStatic(core.clj:64)
    at clojure.core.protocols$fn__7852.invokeStatic(protocols.clj:169)
    at clojure.core.protocols$fn__7852.invoke(protocols.clj:124)
    at clojure.core.protocols$fn__7807$G__7802__7816.invoke(protocols.clj:19)
    at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:31)
    at clojure.core.protocols$fn__7835.invokeStatic(protocols.clj:75)
    at clojure.core.protocols$fn__7835.invoke(protocols.clj:75)
    at clojure.core.protocols$fn__7781$G__7776__7794.invoke(protocols.clj:13)
    at clojure.core$reduce.invokeStatic(core.clj:6748)
    at clojure.core$into.invokeStatic(core.clj:6815)
    at clojure.core$into.invoke(core.clj:6807)
    at com.climate.squeedo.sqs$clojurify_message_attributes.invokeStatic(sqs.clj:239)
    at com.climate.squeedo.sqs$clojurify_message_attributes.invoke(sqs.clj:230)
    at com.climate.squeedo.sqs$message_map.invokeStatic(sqs.clj:244)
    at com.climate.squeedo.sqs$message_map.invoke(sqs.clj:241)
    at clojure.core$partial$fn__5561.invoke(core.clj:2616)
    at clojure.core$map$fn__5587.invoke(core.clj:2747)
    at clojure.lang.LazySeq.sval(LazySeq.java:40)
    at clojure.lang.LazySeq.seq(LazySeq.java:49)
    at clojure.lang.RT.seq(RT.java:528)
    at clojure.core$seq__5124.invokeStatic(core.clj:137)
    at clojure.core$map$fn__5587.invoke(core.clj:2738)
    at clojure.lang.LazySeq.sval(LazySeq.java:40)
    at clojure.lang.LazySeq.seq(LazySeq.java:49)
    at clojure.lang.RT.seq(RT.java:528)
    at clojure.core$seq__5124.invokeStatic(core.clj:137)
    at clojure.core$seq__5124.invoke(core.clj:137)
    at clojure.core.async$onto_chan$fn__18872$state_machine__17798__auto____18879$fn__18881.invoke(async.clj:643)
    at clojure.core.async$onto_chan$fn__18872$state_machine__17798__auto____18879.invoke(async.clj:643)
    at clojure.core.async.impl.ioc_macros$run_state_machine.invokeStatic(ioc_macros.clj:973)
    at clojure.core.async.impl.ioc_macros$run_state_machine.invoke(ioc_macros.clj:972)
    at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invokeStatic(ioc_macros.clj:977)
    at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke(ioc_macros.clj:975)
    at clojure.core.async$onto_chan$fn__18872.invoke(async.clj:643)
    at clojure.lang.AFn.run(AFn.java:22)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```