### PR TITLE
Add account-id option for cross-account connections

### DIFF
--- a/src/com/climate/squeedo/sqs.clj
+++ b/src/com/climate/squeedo/sqs.clj
@@ -17,6 +17,7 @@
   (:import
     (com.amazonaws.services.sqs.model
       CreateQueueRequest
+      GetQueueUrlRequest
       Message
       MessageAttributeValue
       QueueDoesNotExistException
@@ -168,11 +169,13 @@
 
   Will throw QueueDoesNotExistException if the queue does not exist.
   `configure-queue` can be used to create and configure the queue."
-  [^String queue-name & {:keys [client] :as options}]
+  [^String queue-name & {:keys [client account-id] :as options}]
   (dead-letter-deprecation-warning options)
   (validate-queue-name! queue-name)
   (let [^AmazonSQS client (or client (default-client))
-        queue-url (.getQueueUrl (.getQueueUrl client queue-name))]
+        get-queue-url-request (doto (GetQueueUrlRequest. queue-name)
+                                (.setQueueOwnerAWSAccountId account-id))
+        queue-url (.getQueueUrl (.getQueueUrl client get-queue-url-request))]
     (log/infof "Using SQS queue %s at %s" queue-name queue-url)
     {:client client
      :queue-name queue-name

--- a/src/com/climate/squeedo/sqs_consumer.clj
+++ b/src/com/climate/squeedo/sqs_consumer.clj
@@ -190,6 +190,7 @@
     :max-concurrent-work       - the maximum number of total messages processed.  This is mainly for async workflows;
                                  default num-workers
     :client                    - the SQS client to use (if missing, sqs/mk-connection will create a client)
+    :account-id                - the AWS account ID for cross-account connections
     :exceptional-poll-delay-ms - when an Exception is received while polling, the number of ms we wait until polling
                                  again.  Default is 10000 (10 seconds).
    Output:
@@ -198,7 +199,7 @@
   [queue-name compute & opts]
   (let [options (->options-map opts)
         _ (dead-letter-deprecation-warning options)
-        connection (sqs/mk-connection queue-name :client (:client options))
+        connection (sqs/mk-connection queue-name :client (:client options) (:account-id options))
         worker-count (get-worker-count options)
         listener-count (get-listener-count worker-count options)
         message-chan-size (get-message-channel-size listener-count options)


### PR DESCRIPTION
This pull request adds ability for the clients to connect to the queues that reside in different AWS accounts. Appropriate policies must be set in those accounts to allow access.

A new option `account-id` has been added to support this behavior. If the `account-id` is not provided, then the default behavior is to connect to the queue in the client's current account.